### PR TITLE
Hide [OPTIONS] and skip main command 

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -38,6 +38,9 @@ Once enabled, *sphinx-click* enables automatic documentation for
    ``:show-nested:``
      Enable full documentation for sub-commands.
 
+   ``:flat-toctree:``
+     Generate a flat toctree for nested commands (by a hierarchical one is generated)
+
    ``:commands:``
      Document only listed commands.
 


### PR DESCRIPTION
- [OPTIONS] are hidden in usage, where there are no command options. (flag is :hide-options-in-usage:)
- Main command is skipped from toctree and main body (flag is :skip-main-command:)